### PR TITLE
Prompt policies update

### DIFF
--- a/mantiumapi/security.py
+++ b/mantiumapi/security.py
@@ -158,3 +158,10 @@ class Action(ApiModel):
         repository = repositories.Repository(self._options.api.type_registry)
         repository.add(self)
         repository.update_from_api_response(jsonapi_response)
+
+
+class PromptPolicy(ApiModel):
+
+    class Meta:
+        type = "prompt_policy"
+        api = orm_api

--- a/mantiumapi/version.py
+++ b/mantiumapi/version.py
@@ -16,5 +16,5 @@
 # Please refer to our terms for more information:
 #     https://mantiumai.com/terms-of-use/
 #
-__version__ = '0.1.51'
+__version__ = '0.1.52'
 


### PR DESCRIPTION
Temporary update until prompt_security output is resolved. This is to keep prompts with security policies failing to load due to the "prompt_policy" relationships

